### PR TITLE
Fix - notice color and location

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,3 +1,18 @@
+  <% if notice %>
+    <div class="row d-none">
+      <div class="col">
+        <div class="alert alert-info alert-dismissible fade show" role="alert">
+          <p id="notice" class="p-0 m-0">
+            <%= notice %>
+          </p>
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
 <div class="jumbotron-fluid custom-home">
 	<div id="myCarousel" class="carousel slide" data-ride="carousel">
 		<ol class="carousel-indicators">

--- a/app/views/user_profiles/show.html.erb
+++ b/app/views/user_profiles/show.html.erb
@@ -2,7 +2,11 @@
   <% if notice %>
     <div class="row">
       <div class="col">
-        <div class="alert alert-info alert-dismissible fade show" role="alert">
+        <% if notice == 'Invalid Postal Code.' %>
+          <div class="alert alert-warning alert-dismissible fade show" role="alert">
+        <% else %>
+          <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <% end %>
           <p id="notice" class="p-0 m-0"><%= notice %></p>
           <button type="button" class="close" data-dismiss="alert" aria-label="Close">
             <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
after sign in - relocate to home page - after that, notice doesn't show up in user profile page
also, notice color is set to yellow when postal code is invalid, and green when user profile updated successfully.